### PR TITLE
Activate mathjax support.

### DIFF
--- a/PITCHME.yaml
+++ b/PITCHME.yaml
@@ -4,3 +4,4 @@ transition : fade
 charts : true
 slide-number: true
 footnote : "FoxTrack"
+mathjax : TeX-AMS_HTML-full


### PR DESCRIPTION
By default MathJax formulas are disabled. See [GitPitch wiki for details](https://github.com/gitpitch/gitpitch/wiki/Math-Notation-Setting). Use the `mathjax` property in `PITCHME.yaml` to activate math formulas within GitPitch presentations.